### PR TITLE
Fix protocol of msg mode in status msg

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -7,7 +7,7 @@
 using namespace motoman_mh12;
 
 Driver::Driver()
-: iodrivers_base::Driver(10*msgs::MOTOMAN_MAX_PKT_SIZE) 
+: iodrivers_base::Driver(10*msgs::MOTOMAN_MAX_PKT_SIZE)
 {
     buffer.resize(10*msgs::MOTOMAN_MAX_PKT_SIZE);
 }
@@ -23,22 +23,22 @@ msgs::MotomanMsgType Driver::read(base::Time timeout)
 int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const
 {
     int32_t const* buffer_as_int32 = reinterpret_cast<int32_t const*>(buffer);
-    
+
     if(buffer_size < sizeof(int32_t)*2)
         return 0;
-    
+
     int length = buffer_as_int32[0];
     int msg_type = buffer_as_int32[1];
     int expected_length = msgs::returnMsgSize(msg_type);
-    
+
     if(length != expected_length)
         return -1;
-    
+
     if(buffer_size>=length)
         return expected_length;
     else
         return 0;
-    
+
 }
 
 msgs::MotomanMsgType Driver::parsePacket(uint8_t const* buffer, size_t size)
@@ -53,7 +53,7 @@ msgs::MotomanMsgType Driver::parsePacket(uint8_t const* buffer, size_t size)
             joint_feedback = parseJointFeedback(buffer);
             return msgs::MOTOMAN_JOINT_FEEDBACK;
         default:
-            throw std::runtime_error("Invalid msg type received"); 
+            throw std::runtime_error("Invalid msg type received");
     }
 }
 
@@ -81,7 +81,10 @@ msgs::MotomanStatus Driver::parseReadStatus(uint8_t const* buffer, size_t size) 
         motoman_status.error_code = int(msg.error_code);
     motoman_status.ln_error = interpret_tristate(msg.ln_error);
     motoman_status.ln_motion = interpret_tristate(msg.ln_motion);
-    motoman_status.mode = interpret_tristate(msg.mode);
+    if (msg.mode == 2)
+        motoman_status.mode = true;
+    else
+        motoman_status.mode = false;
     motoman_status.motion_possible = interpret_tristate(msg.motion_possible);
     return motoman_status;
 }
@@ -96,7 +99,7 @@ msgs::MotomanJointFeedback Driver::parseJointFeedback(uint8_t const* buffer) con
     //must be always 6
     if(parsed_joint_feedback.valid_field !=6)
         throw std::runtime_error("Bit-masking of valid fields inconsistent");
-    
+
     parsed_joint_feedback.time.fromSeconds(msg.time);
     for(int i = 0; i<10; i++)
     {
@@ -104,7 +107,7 @@ msgs::MotomanJointFeedback Driver::parseJointFeedback(uint8_t const* buffer) con
         joint_state.position = double(msg.positions[i]);
         parsed_joint_feedback.joint_states.push_back(joint_state);
     }
-    
+
     return parsed_joint_feedback;
 }
 
@@ -133,7 +136,7 @@ float removeNaNs(float a)
 msgs::MotionReply Driver::sendJointTrajPTFullCmd(int robot_id, int sequence_id, base::samples::Joints const& joints_samples)
 {
     msgs::JointTrajPTFullMsg joint_traj_cmd;
-    joint_traj_cmd.prefix.length = msgs::MOTOMAN_JOINT_TRAJ_PT_FULL_SIZE; 
+    joint_traj_cmd.prefix.length = msgs::MOTOMAN_JOINT_TRAJ_PT_FULL_SIZE;
     joint_traj_cmd.prefix.msg_type = msgs::MOTOMAN_JOINT_TRAJ_PT_FULL;
     joint_traj_cmd.robot_id = int32_t(robot_id);
     joint_traj_cmd.sequence_id = int32_t(sequence_id);
@@ -143,7 +146,7 @@ msgs::MotionReply Driver::sendJointTrajPTFullCmd(int robot_id, int sequence_id, 
         joint_traj_cmd.positions[i] =  removeNaNs(joints_samples[i].position);
         joint_traj_cmd.velocities[i] = removeNaNs(joints_samples[i].speed);
         joint_traj_cmd.accelerations[i] = removeNaNs(joints_samples[i].acceleration);
-    
+
     }
     uint8_t const* buffer = reinterpret_cast<uint8_t const*>(&joint_traj_cmd);
     writePacket(buffer, joint_traj_cmd.prefix.length + 4);
@@ -153,7 +156,7 @@ msgs::MotionReply Driver::sendJointTrajPTFullCmd(int robot_id, int sequence_id, 
 void Driver::waitForReply(base::Time const& timeout, int32_t msg_type)
 {
     base::Timeout deadline(timeout);
-    
+
     while(!deadline.elapsed())
     {
         int packet_size = readPacket(&buffer[0], buffer.size(), deadline.timeLeft());

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -183,7 +183,7 @@ msgs::MotionReply Driver::sendMotionCtrl(int robot_id, int sequence_id, int cmd)
     msgs::MotionCtrlMsg motion_ctrl(robot_id, sequence_id, cmd);
     uint8_t const* buffer = reinterpret_cast<uint8_t const*>(&motion_ctrl);
     writePacket(buffer, motion_ctrl.prefix.length + 4);
-    return readMotionCtrlReply(base::Time::fromSeconds(1));
+    return readMotionCtrlReply(base::Time::fromSeconds(2));
 }
 
 msgs::MotionReply Driver::readJointPositionReply(const base::Time& timeout)

--- a/src/Msgs.hpp
+++ b/src/Msgs.hpp
@@ -40,15 +40,15 @@ namespace motoman_mh12
         };
         static const int LENGTH_UNKNOWN = -1;
         int returnMsgSize(int msg_type);
-        
-        //every message must start with this prefix 
+
+        //every message must start with this prefix
         struct Prefix
         {
             int32_t length;
             int32_t msg_type;
             int32_t comm_type; //!< still unclear what is supposed to be filled here
             int32_t reply_code; //!< still unclear what is supposed to be filled here
-            
+
             Prefix(){}
             Prefix(msgs::MotomanMsgType msg_type):
             msg_type(msg_type),
@@ -56,7 +56,7 @@ namespace motoman_mh12
             reply_code(0)
             {
                 length = returnMsgSize(msg_type);
-            } 
+            }
             Prefix(msgs::MotomanMsgType msg_type, msgs::CommType comm_type):
             msg_type(msg_type),
             comm_type(comm_type),
@@ -64,28 +64,28 @@ namespace motoman_mh12
             {
                 length = returnMsgSize(msg_type);
             }
-            
+
         }__attribute__((packed));
-        
+
         struct StatusMsg
         {
             Prefix prefix;
             int32_t drives_powered; //!< -1=Unkown, 1=ON, 0=OFF
             int32_t e_stopped; //!< Controller E-Stop state -1 = Unknown; 1 = TRUE(ON); 0 = FALSE(OFF)
-            int32_t error_code; //!< Alarm code of the first current alarm -1 = Unknown; 
-            //0 = No alarm; Other = Alarm# 
-            int32_t ln_error; //!< There is at least one active alarm -1 = Unknown; 
+            int32_t error_code; //!< Alarm code of the first current alarm -1 = Unknown;
+            //0 = No alarm; Other = Alarm#
+            int32_t ln_error; //!< There is at least one active alarm -1 = Unknown;
             //1 = TRUE(ON); 0 = FALSE(OFF)
-            int32_t ln_motion; //!< The controller is executing a job(program) -1 = Unknown; 1 = TRUE(ON) 
+            int32_t ln_motion; //!< The controller is executing a job(program) -1 = Unknown; 1 = TRUE(ON)
             //0 = FALS(OFF)
             int32_t mode; //!< Controller/Pendant mode -1 = Unkown; 1=Manual(Teach); 0= Auto(Play or Remtote)
             int32_t motion_possible; //!< Controller can receive motion for ROS -1=Unknown; 1=Enabled; 0=Disabled
-            
+
             StatusMsg(){}
             StatusMsg(int drives_powered, int e_stopped, int error_code,
                       int ln_error, int ln_motion, int mode, int motion_possible):
                       prefix(MOTOMAN_ROBOT_STATUS),
-                      drives_powered(drives_powered), 
+                      drives_powered(drives_powered),
                       e_stopped(e_stopped),
                       error_code(error_code),
                       ln_error(ln_error),
@@ -93,9 +93,9 @@ namespace motoman_mh12
                       mode(mode),
                       motion_possible(motion_possible){}
         }__attribute__((packed));
-        
+
         /*
-         * \brief This message is used to send motion commands to control and manage the overall motion    
+         * \brief This message is used to send motion commands to control and manage the overall motion
          */
         struct MotionCtrlMsg
         {
@@ -104,30 +104,30 @@ namespace motoman_mh12
             int32_t sequence_id;
             int32_t cmd; //!< motion command motion_ctrl::MotionControlCmd
             float data[10] = {0};
-            
+
             MotionCtrlMsg(int robot_id, int sequence_id, int cmd):
             prefix(MOTOMAN_MOTION_CTRL, SERVICE_REQUEST),
             robot_id(robot_id),
             sequence_id(sequence_id),
             cmd(cmd){}
         }__attribute__((packed));
-        
+
         /*
-         * \brief MotoROS sends this reply message each time it receives 
+         * \brief MotoROS sends this reply message each time it receives
          * a joint trajectory message or a motoman motion control command.
          */
         struct MotionReplyMsg
         {
             Prefix prefix;
-            int32_t robot_id; 
-            int32_t sequence_id; //!<Reference to the sequence_id number that is being responded to. 
-            int32_t command; //!< Reference to the command or message type 
-            //that is being responded to. MotomanMsgType::JOINT_TRAJ_FULL 
+            int32_t robot_id;
+            int32_t sequence_id; //!<Reference to the sequence_id number that is being responded to.
+            int32_t command; //!< Reference to the command or message type
+            //that is being responded to. MotomanMsgType::JOINT_TRAJ_FULL
             //or motion_ctrl::MotionControlCmd
             int32_t result;  //result code (motion_ctrl::MotionReplyResult)
             int32_t subcode;
             float data[10];
-            
+
             MotionReplyMsg(){}
             MotionReplyMsg(int robot_id, int sequence_id, int command, int result, int subcode):
             prefix(MOTOMAN_MOTION_REPLY),
@@ -137,7 +137,7 @@ namespace motoman_mh12
             result(result),
             subcode(subcode){}
         }__attribute__((packed));
-        
+
         struct MotionReply
         {
             int robot_id;
@@ -159,20 +159,20 @@ namespace motoman_mh12
         struct ReadSingleIoMsg
         {
             Prefix prefix;
-            int32_t address; //!< Address of the controller I/O signal to be read. Values from 00010 to 1000559, please refer to the controller Concurrent I/O Manual for details on addresses.  
-            
+            int32_t address; //!< Address of the controller I/O signal to be read. Values from 00010 to 1000559, please refer to the controller Concurrent I/O Manual for details on addresses.
+
             ReadSingleIoMsg(){}
             ReadSingleIoMsg(int address):
             prefix(MOTOMAN_READ_SINGLE_IO),
             address(address){}
         }__attribute__((packed));
-        
+
         struct ReadSingleIoReplyMsg
         {
             Prefix prefix;
             int32_t value; //State of the I/O. 0=OFF, 1=ON
             int32_t result_code; //High level command resul code: 1=SUCCESS 2= FAILURE
-            
+
             ReadSingleIoReplyMsg(){}
             ReadSingleIoReplyMsg(int value, int result_code):
                 prefix(MOTOMAN_READ_SINGLE_IO_REPLY),
@@ -186,43 +186,43 @@ namespace motoman_mh12
             int value;
             int result;
         };
-        
+
         struct WriteSingleIoMsg
         {
             Prefix prefix;
-            int32_t io_address;  //!< Address of the controller I/O signal to be read. Values from 00010 to 1000559, please refer to the controller Concurrent I/O Manual for details on addresses.  
+            int32_t io_address;  //!< Address of the controller I/O signal to be read. Values from 00010 to 1000559, please refer to the controller Concurrent I/O Manual for details on addresses.
             int32_t value; //!< State of the I/O; 0=OFF and 1=ON.
-            
+
             WriteSingleIoMsg(int io_address, int value):
             prefix(MOTOMAN_WRITE_SINGLE_IO),
             io_address(io_address),
             value(value){}
         }__attribute__((packed));
-        
+
         struct WriteSingleIoReplyMsg
         {
             Prefix prefix;
             int32_t result_code; //!< Result code write_single_io::ResultCode: SUCCESS = 1, FAILURE = 2.
-            
+
             WriteSingleIoReplyMsg(){}
             WriteSingleIoReplyMsg(int result_code):
             prefix(MOTOMAN_WRITE_SINGLE_IO_REPLY),
             result_code(result_code){}
         }__attribute__((packed));
-        
-        
+
+
         struct MotomanStatus
         {
-            //encanpsulation of the message excluding the unknown states, if there is the need we can implement it later    
+            //encanpsulation of the message excluding the unknown states, if there is the need we can implement it later
             bool drives_powered;
             bool e_stopped; //!< Controller E-Stop state 1 = TRUE(ON); 0 = FALSE(OFF)
-            int error_code; //!< Alarm code of the first current alarm 0 = No alarm; Other = Alarm# 
+            int error_code; //!< Alarm code of the first current alarm 0 = No alarm; Other = Alarm#
             bool ln_error; //!< There is at least one active alarm 1 = TRUE(ON); 0 = FALSE(OFF)
             bool ln_motion; //!< The controller is executing a job(program) 1 = TRUE(ON) 0 = FALSE(OFF)
             bool mode; //!< Controller/Pendant mode 1=Manual(Teach); 0= Auto(Play or Remtote)
             bool motion_possible; //!< Controller can receive motion for ROS 1=Enabled; 0=Disabled
         };
-        
+
         struct JointFeedbackMsg
         {
             Prefix prefix;
@@ -230,23 +230,23 @@ namespace motoman_mh12
             int32_t valid_field;
             float time;
             float positions[10];
-            float velocities[10]; 
+            float velocities[10];
             float accelerations[10];
         }__attribute__((packed));
-        
+
         struct MotomanJointFeedback
         {
             int robot_id; // 0 = 1st robot
             int valid_field; // Bit-mask indicating which “optional” fields are filled with data.
-            //1 = time, 2 = position, 4 = velocity, 8 = acceleration 
+            //1 = time, 2 = position, 4 = velocity, 8 = acceleration
             //MotoROS only send position, so this value should be set to 2.
             base::Time time; //timestamp associated with this trajectory point in seconds
             std::vector<base::JointState> joint_states;
         };
         /*
          * \brief The message called JOINT_TRAJ_PT_FULL type which includes position,
-         * velocity, acceleration and time is designated as type 14. This type of message 
-         * contains sufficient trajectory data to accurately reproduce the trajectory 
+         * velocity, acceleration and time is designated as type 14. This type of message
+         * contains sufficient trajectory data to accurately reproduce the trajectory
          * generated by the compute with matching speed profile
          */
         struct JointTrajPTFullMsg
@@ -259,11 +259,11 @@ namespace motoman_mh12
             float positions[10];//!< Desired joint positions in radian. Ordering matches the sequential joint order: SLURBT for 6 axis robot and SLEURBT for 7 axis robots.
             float velocities[10]; //!< Desired joint velocities in radian/sec. Same ordering as positions.
             float accelerations[10]; //!< Desired joint accelerations in radians/sec2. Same orderins as positions.
-            
+
             JointTrajPTFullMsg():
             prefix(MOTOMAN_JOINT_TRAJ_PT_FULL, SERVICE_REQUEST){}
         }__attribute__((packed));
-        
+
         enum MotomanMsgSize
         {
             MOTOMAN_PREFIX_MSG_SIZE = sizeof(msgs::Prefix),
@@ -307,11 +307,11 @@ namespace motoman_mh12
                 default:
                     return LENGTH_UNKNOWN;
             }
-        } 
+        }
         namespace rs232_msgs
         {
             static const uint16_t MOTOMAN_MH12_DLE = 0x10; //!<Data Link Escape
-            static const uint16_t MOTOMAN_MH12_SOH = 0x01; //!<Start of Heading 
+            static const uint16_t MOTOMAN_MH12_SOH = 0x01; //!<Start of Heading
             static const uint16_t MOTOMAN_MH12_STX = 0x02; //!<Start of Text
             static const uint16_t MOTOMAN_MH12_ETX = 0x03; //!<End of Text
             static const uint16_t MOTOMAN_MH12_EOT = 0x04; //!<End of Transmission
@@ -322,10 +322,10 @@ namespace motoman_mh12
             static const uint16_t MOTOMAN_MH12_ACK1 = 0x31; //!<Odd Affirmative Acknowledgment
             static const uint16_t MOTOMAN_MH12_ACK = 0x10; //!<Affirmative Acknowledgment
         }
-        
+
         //messages used in the interface with MOTO ROS and gathered from the simple_message package
         //https://github.com/ros-industrial/motoman
-        
+
         namespace motion_ctrl
         {
             /**
@@ -346,7 +346,7 @@ namespace motoman_mh12
         }
         namespace motion_reply
         {
-            
+
             /**
              * \brief Enumeration of motion reply result codes.
              */
@@ -363,9 +363,9 @@ namespace motoman_mh12
                     MP_FAILURE = 6
                 };
             }
-            
+
             typedef MotionReplyResults::MotionReplyResult MotionReplyResult;
-            
+
             /*
              * \brief Enumeration of Motion reply subcodes
              */
@@ -390,7 +390,7 @@ namespace motoman_mh12
                         DATA_INSUFFICIENT
                     };
                 }  // namespace Invalid
-                
+
                 namespace NotReady
                 {
                     enum NotReadyCode
@@ -410,7 +410,7 @@ namespace motoman_mh12
                 }  // namespace NotReady
             }  // MotionReplySubcodes
         }
-        
+
         namespace single_io
         {
             namespace Value
@@ -429,8 +429,8 @@ namespace motoman_mh12
                     FAILURE = 2
                 };
             }
-        }  
-        
+        }
+
     }
 }
-#endif    
+#endif

--- a/src/TestHelpers.hpp
+++ b/src/TestHelpers.hpp
@@ -35,9 +35,9 @@ int send_joint_cmd(Driver& driver_ctrl, int sequence_id, base::samples::Joints t
     // Record start time
     base::Time start = base::Time::now();
     while(true){
-        
+
         reply = driver_ctrl.sendJointTrajPTFullCmd(0, sequence_id, target_position);
-        
+
         if (reply.result == 1)
         {
             busy++;
@@ -49,7 +49,7 @@ int send_joint_cmd(Driver& driver_ctrl, int sequence_id, base::samples::Joints t
             printMotionReply(reply);
             std::cout << "It took " << elapsed << " ms" << " and " << busy << " tries" << std::endl;
             break;
-        } 
+        }
     }
 }
 
@@ -72,6 +72,3 @@ base::samples::Joints readCurrentPosition(Driver &driver)
     }
 }
 }
-
-
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 rock_gtest(test_Driver
    test_Driver.cpp
    HEADERS
-   LIBS ${Boost_SYSTEM_LIBRARY} 
+   LIBS ${Boost_SYSTEM_LIBRARY}
    DEPS motoman_mh12)
 
 rock_executable(test_control_mh12
@@ -22,4 +22,8 @@ rock_executable(test_add_to_queue
 
 rock_executable(test_single_io
     test_single_io.cpp
+    DEPS motoman_mh12)
+
+rock_executable(test_mult_cmd
+    test_stop_start_mult.cpp
     DEPS motoman_mh12)

--- a/test/test_stop_start_mult.cpp
+++ b/test/test_stop_start_mult.cpp
@@ -1,0 +1,47 @@
+#include <motoman_mh12/Msgs.hpp>
+#include <motoman_mh12/Driver.hpp>
+#include <base/JointState.hpp>
+#include <base/JointsTrajectory.hpp>
+#include <motoman_mh12/TestHelpers.hpp>
+#include <iostream>
+#include <math.h>
+
+using namespace motoman_mh12;
+
+int main(int argc, char **argv)
+{
+    Driver driver_ctrl;
+    driver_ctrl.openTCP("192.168.10.77", 50240);
+
+    Driver driver_streaming;
+    driver_streaming.openTCP("192.168.10.77", 50241);
+    driver_streaming.setExtractLastPacket(true);
+
+    std::cout << "Connected" << std::endl;
+    base::samples::Joints current_position = readCurrentPosition(driver_streaming);
+
+
+    //Test the behavior of sending multiple start and stop commands
+
+    for(int i=0; i<10; i++)
+    {
+        msgs::MotionReply reply = driver_ctrl.sendMotionCtrl(
+            0, 0, msgs::motion_ctrl::MotionControlCmds::START_TRAJ_MODE);
+        if(reply.result != msgs::motion_reply::MotionReplyResults::SUCCESS)
+            printMotionReply(reply);
+    }
+    for(int i=0; i<10; i++)
+    {
+        msgs::MotionReply reply = driver_ctrl.sendMotionCtrl(
+            0, 0, msgs::motion_ctrl::MotionControlCmds::STOP_MOTION);
+        if(reply.result != msgs::motion_reply::MotionReplyResults::SUCCESS)
+            printMotionReply(reply);
+    }
+    for(int i=0; i<10; i++)
+    {
+        msgs::MotionReply reply = driver_ctrl.sendMotionCtrl(
+            0, 0, msgs::motion_ctrl::MotionControlCmds::STOP_TRAJ_MODE);
+        if(reply.result != msgs::motion_reply::MotionReplyResults::SUCCESS)
+            printMotionReply(reply);
+    }
+}


### PR DESCRIPTION
In the documentation is 0 for play and remote mode and 1 for tech mode of the pendant. However the controller sends 2 for play and remote mode and 1 for teach. 